### PR TITLE
Train Test split functionality to both training and benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.csv
 .DS_Store
 *.wav
+*.txt
 data/
 
 # Byte-compiled / optimized / DLL files

--- a/benchmark_attacks.py
+++ b/benchmark_attacks.py
@@ -8,6 +8,19 @@ from environment.audio_env import AudioObfuscationEnv
 import soundfile as sf
 import scipy.signal as signal
 
+FOLDER = "testing_data/"
+
+def get_audio_data(folder_path):
+    """
+    Given a path, find all files in that path that ends with ".waw" and returns them.
+    """
+    files = os.listdir(folder_path)
+    audio_files = [folder_path + f for f in files if f.endswith(".wav")]
+    transcriptions = [f.replace(".wav", ".txt") for f in audio_files]
+    dataset = [
+        {"audio_file": f, "transcription": t} for f, t in zip(audio_files, transcriptions)
+    ]
+    return dataset
 
 def random_noise_attack(epsilon, data):
     noise = np.random.uniform(-epsilon, epsilon, data.shape)
@@ -89,14 +102,9 @@ def calculate_measurements(attack, filepath, env, sr, asr_model, original_transc
 
 
 if __name__ == "__main__":
-    files = os.listdir(
-        "data/archive/Raw JL corpus (unchecked and unannotated)/JL(wav+txt)")
-    audio_files = [
-        "data/archive/Raw JL corpus (unchecked and unannotated)/JL(wav+txt)/" + f for f in files if f.endswith(".wav")]
-    transcriptions = [f.replace(".wav", ".txt") for f in audio_files]
-    dataset = [
-        {"audio_file": f, "transcription": t} for f, t in zip(audio_files, transcriptions)
-    ]
+    if not os.path.exists(FOLDER):
+        exit("Test folder does not exist.")
+    dataset = get_audio_data(FOLDER)
     device = "cuda" if torch.cuda.is_available() else "cpu"
     asr_model = whisper.load_model("base").to(device)
 

--- a/data_splitting.py
+++ b/data_splitting.py
@@ -1,0 +1,85 @@
+import os
+import numpy as np
+
+FOLDER = "data/archive/Raw JL corpus (unchecked and unannotated)/JL(wav+txt)/"
+SR = 44100
+TRAIN_TEST_SPLIT = 0.7
+
+def get_audio_data(folder_path):
+    """
+    Given a path, find all files in that path that ends with ".waw" and returns them.
+    """
+    files = os.listdir(folder_path)
+    audio_files = [folder_path + f for f in files if f.endswith(".wav")]
+    transcriptions = [f.replace(".wav", ".txt") for f in audio_files]
+    dataset = [
+        {"audio_file": f, "transcription": t} for f, t in zip(audio_files, transcriptions)
+    ]
+    return dataset
+
+def resplit_data(dataset, tr_folder, te_folder):
+    """
+    Given a dataset, split it into training and testing data.
+    """
+    train_folder = tr_folder
+    test_folder = te_folder
+
+    if os.path.exists(train_folder) and os.path.exists(test_folder):
+        print("Training and Testing data already exists. Will reshuffle the data.")
+        # Put both training and testing data into the same folder
+        train_dict = get_audio_data(train_folder)
+        test_dict = get_audio_data(test_folder)
+
+        dataset = train_dict + test_dict
+        print(f"Total number of files: {len(dataset)}")
+
+        rename_files(dataset, FOLDER)
+        
+
+def rename_files(dataset, folder):
+    """
+    Given a dataset, rename the files in the folder.
+    """
+    for i, data in enumerate(dataset):
+        # Rename the files
+        audio_file = data["audio_file"].split("/")[-1]
+        transcription = data["transcription"].split("/")[-1]
+        os.rename(data["audio_file"], f"{folder}{audio_file}")
+        os.rename(data["transcription"], f"{folder}{transcription}")
+
+
+def train_test_split(dataset, tr_folder, te_folder, split=0.8):
+    """
+    Given a dataset, split it into training and testing data.
+    """
+    train_folder = tr_folder
+    test_folder = te_folder
+
+    if os.path.exists(train_folder) and os.path.exists(test_folder):
+        resplit_data(dataset, tr_folder, te_folder)
+
+    print("Creating new training and testing data. It won't take long - DO NOT INTERRUPT.")
+    dataset = get_audio_data(FOLDER)
+
+    os.makedirs(train_folder, exist_ok=True)
+    os.makedirs(test_folder, exist_ok=True)
+    # Shuffle the dataset
+    np.random.shuffle(dataset)
+
+    # Split the dataset into training and testing
+    split = int(len(dataset)*TRAIN_TEST_SPLIT)
+    train_dataset = dataset[:split]
+    test_dataset = dataset[split:]
+
+    rename_files(train_dataset, train_folder)
+    rename_files(test_dataset, test_folder)
+
+    print("Done!")
+
+if __name__ == "__main__":
+    train_folder = "training_data/"
+    test_folder = "testing_data/"
+    train_test_split(FOLDER, train_folder, test_folder, TRAIN_TEST_SPLIT)
+
+    
+

--- a/trainMEL.py
+++ b/trainMEL.py
@@ -9,8 +9,12 @@ import numpy as np
 import keras
 from environment.mel_env import MelAudioObfuscationEnv
 from models.ddpg import DDPG
+from data_splitting import train_test_split
 
-WAW_FILEPATH = "data/archive/Raw JL corpus (unchecked and unannotated)/JL(wav+txt)/"
+DATA_FOLDER = "data/archive/Raw JL corpus (unchecked and unannotated)/JL(wav+txt)/"
+TRAINING_FILEPATH = "training_data/"
+TESTING_FILEPATH = "testing_data/"
+RESHUFFLE = False
 RUNS_PER_EPISODE = 10
 TOTAL_EPISODES = 100
 AUDIO_LENGTH = 257
@@ -98,6 +102,8 @@ def update_target(target, original, tau):
 
     target.set_weights(target_weights)
 
-DATASET = get_audio_data(WAW_FILEPATH)
 if __name__ == "__main__":
-    train()
+    if not os.path.exists(TRAINING_FILEPATH) or RESHUFFLE:
+        train_test_split(DATA_FOLDER, TRAINING_FILEPATH, TESTING_FILEPATH, 0.7)
+    dataset = get_audio_data(TRAINING_FILEPATH)
+    train(dataset)

--- a/trainSTFT.py
+++ b/trainSTFT.py
@@ -9,20 +9,24 @@ import numpy as np
 import keras
 from environment.stft_env import STFTAudioObfuscationEnv
 from models.ddpg import DDPG
+from data_splitting import train_test_split
 
-WAW_FILEPATH = "data/archive/Raw JL corpus (unchecked and unannotated)/JL(wav+txt)/"
+DATA_FOLDER = "data/archive/Raw JL corpus (unchecked and unannotated)/JL(wav+txt)/"
+TRAINING_FILEPATH = "training_data/"
+TESTING_FILEPATH = "testing_data/"
+RESHUFFLE = False
 TOTAL_EPISODES = 100
 AUDIO_LENGTH = 257
 RUNS_PER_EPISODE = 10
 
-def train():
+def train(dataset):
     """
     Trains a DDPG Agent with environment AudioObfuscationEnv
     """
     ep_reward_list = []
     avg_reward_list = []
 
-    env = STFTAudioObfuscationEnv(DATASET, get_asr(), AUDIO_LENGTH)
+    env = STFTAudioObfuscationEnv(dataset, get_asr(), AUDIO_LENGTH)
     agent = DDPG(AUDIO_LENGTH, AUDIO_LENGTH, 2)
 
     for ep in range(TOTAL_EPISODES):
@@ -96,6 +100,8 @@ def update_target(target, original, tau):
 
     target.set_weights(target_weights)
 
-DATASET = get_audio_data(WAW_FILEPATH)
 if __name__ == "__main__":
-    train()
+    if not os.path.exists(TRAINING_FILEPATH) or RESHUFFLE:
+        train_test_split(DATA_FOLDER, TRAINING_FILEPATH, TESTING_FILEPATH, 0.7)
+    dataset = get_audio_data(TRAINING_FILEPATH)
+    train(dataset)


### PR DESCRIPTION
This pull request will bring over the functionalities to split the training and testing data. Training can be done in the same way as before, no need to run another file. However, you have to run the training at least once before running the benchmarks now.